### PR TITLE
Doodle should now rotate right

### DIFF
--- a/src/main/java/chalmers/pimp/model/canvas/layer/Doodle.java
+++ b/src/main/java/chalmers/pimp/model/canvas/layer/Doodle.java
@@ -69,8 +69,8 @@ final class Doodle implements ILayer {
 
   @Override
   public void setRotationAnchorToCenter() {
-    Point temp = new Point(layerDelegate.getX() + (getWidth() / 2),
-        layerDelegate.getY() + (getHeight() / 2));
+    Point temp = new Point(getX() + (getWidth() / 2),
+        getY() + (getHeight() / 2));
     layerDelegate.setRotationAnchor(temp);
   }
 
@@ -96,15 +96,15 @@ final class Doodle implements ILayer {
 
   @Override
   public int getX() {
-    List<Integer> xVlaues = points.stream().map(Point::getX).collect(Collectors.toList());
-    int min = getExtreme(xVlaues, (a, b) -> a > b);
+    List<Integer> xValues = points.stream().map(Point::getX).collect(Collectors.toList());
+    int min = getExtreme(xValues, (a, b) -> a > b);
     return min + layerDelegate.getX();
   }
 
   @Override
   public int getY() {
-    List<Integer> yVlaues = points.stream().map(Point::getY).collect(Collectors.toList());
-    int min = getExtreme(yVlaues, (a, b) -> a > b);
+    List<Integer> yValues = points.stream().map(Point::getY).collect(Collectors.toList());
+    int min = getExtreme(yValues, (a, b) -> a > b);
     return min + layerDelegate.getY();
   }
 
@@ -179,6 +179,7 @@ final class Doodle implements ILayer {
 
   @Override
   public Point getRotationAnchor() {
+    setRotationAnchorToCenter();
     return layerDelegate.getRotationAnchor();
   }
 


### PR DESCRIPTION
Seems like the setRotationAnchor was based on the layerDelegate x and y, which doodle isn't using. @molleer might fix this...